### PR TITLE
Remove unused and duplicate regexp definitions

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,4 @@
 importScripts("search_common.js");
-
-var urlGoMatch = /^go (https?|ftp|file|chrome(-extension)?):\/\/.+/i;
-var urlMatch = /^(https?|ftp|file|chrome(-extension)?):\/\/.+/i;
-var jsMatch = /^javascript:.+/i;
-
 function createTab(url){
 	chrome.tabs.create({
 		'url': url

--- a/src/search_common.js
+++ b/src/search_common.js
@@ -1,5 +1,4 @@
 var urlGoMatch = /^go (https?|ftp|file|chrome(-extension)?):\/\/.+/i;
-var urlMatch = /^(https?|ftp|file|chrome(-extension)?):\/\/.+/i;
 var jsMatch = /^javascript:.+/i;
 
 var bookmarks = (function(){

--- a/src/search_test.js
+++ b/src/search_test.js
@@ -1,7 +1,3 @@
-var urlGoMatch = /^go (https?|ftp|file|chrome(-extension)?):\/\/.+/i;
-var urlMatch = /^(https?|ftp|file|chrome(-extension)?):\/\/.+/i;
-var jsMatch = /^javascript:.+/i;
-
 function escapeXML(str){
 	return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&apos;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }


### PR DESCRIPTION
The `urlGoMatch`, `jsGoMatch`, and `jsMatch` regular expressions were defined in multiple source files, but they only need to be defined in `search_common.js` because that gets sourced by all the other pages.

In addition, `urlMatch` is never used, so it can be removed as well.